### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 ### Other ADSync Commands (might not do all of them).
 - [x] Get-ADSyncAADCompanyFeature
 - [ ] Get-ADSyncADConnectorSchemaDsml
-- [ ] Get-ADSyncAutoUpgrade
+- [x] Get-ADSyncAutoUpgrade
 - [ ] Get-ADSyncConnectorHierarchyProvisioningDNComponent
 - [ ] Get-ADSyncConnectorHierarchyProvisioningMapping
 - [ ] Get-ADSyncConnectorHierarchyProvisioningObjectClass
@@ -34,7 +34,7 @@
 - [ ] Get-ADSyncConnectorPartition
 - [ ] Get-ADSyncConnectorPartitionHierarchy
 - [ ] Get-ADSyncConnectorRunStatus
-- [ ] Get-ADSyncConnectorStatistics
+- [x] Get-ADSyncConnectorStatistics
 - [ ] Get-ADSyncConnectorTypes
 - [ ] Get-ADSyncCSGroupStatistics
 - [ ] Get-ADSyncCSGroupSummary
@@ -42,7 +42,7 @@
 - [ ] Get-ADSyncCSObjectReferences
 - [ ] Get-ADSyncDatabaseConfiguration
 - [x] Get-ADSyncDomainReachabilityStatus
-- [ ] Get-ADSyncExportDeletionThreshold
+- [x] Get-ADSyncExportDeletionThreshold
 - [x] Get-ADSyncGlobalSettings
 - ~~Get-ADSyncGlobalSettingsParameter~~ Covered by Get-ADSyncGlobalSettings
 - [x] Get-ADSyncPartitionPasswordSyncState

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ### Priority Commands
 - [x] Get-ADSyncScheduler
 - [x] Start-ADSyncSyncCycle 
-- [ ] Get-ADSyncAADPasswordResetConfiguration *
+- [x] Get-ADSyncAADPasswordResetConfiguration *
 - [x] Get-ADSyncAADPasswordSyncConfiguration *
 - [x] Get-ADSyncCSObject *
 - [x] Get-ADSyncMVObject *

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 - [ ] Get-ADSyncCSObjectLog
 - [ ] Get-ADSyncCSObjectReferences
 - [ ] Get-ADSyncDatabaseConfiguration
-- [ ] Get-ADSyncDomainReachabilityStatus
+- [x] Get-ADSyncDomainReachabilityStatus
 - [ ] Get-ADSyncExportDeletionThreshold
 - [x] Get-ADSyncGlobalSettings
 - ~~Get-ADSyncGlobalSettingsParameter~~ Covered by Get-ADSyncGlobalSettings

--- a/scripts/Get-ADSyncAADPasswordRestConfiguration.ps1
+++ b/scripts/Get-ADSyncAADPasswordRestConfiguration.ps1
@@ -1,0 +1,8 @@
+﻿
+$connector = @(Get-ADSyncConnector | ? Type -like "Extensible2" | ? Subtype -like "Windows Azure Active Directory*")
+
+if ($connector.Count -gt 1) {
+    throw "Unsupported AADC configuration. More than one AAD connector is not supported."
+}
+
+Get-ADSyncAADPasswordResetConfiguration -Connector ($connector.Name)

--- a/scripts/Get-ADSyncAutoUpgrade.ps1
+++ b/scripts/Get-ADSyncAutoUpgrade.ps1
@@ -1,0 +1,8 @@
+﻿$state  = Get-ADSyncAutoUpgrade -Detail
+$props  = $state | GM | ? MemberType -like "Property"
+$result = New-Object PSObject
+$props | foreach {
+    $val = $state.($_.Name)
+    $result | Add-Member -MemberType NoteProperty -Name ($_.Name) -Value ([string]$val)
+}
+$result

--- a/scripts/Get-ADSyncDomainReachabilityStatusStrict.ps1
+++ b/scripts/Get-ADSyncDomainReachabilityStatusStrict.ps1
@@ -1,0 +1,3 @@
+﻿param ($ConnectorName)
+
+Get-ADSyncDomainReachabilityStatus -ConnectorName $ConnectorName

--- a/scripts/Get-ADSyncRunProfileResultLastHour.ps1
+++ b/scripts/Get-ADSyncRunProfileResultLastHour.ps1
@@ -1,0 +1,7 @@
+﻿
+$lastHour = [DateTime]::UtcNow.AddHours(-1)
+
+Get-ADSyncRunProfileResult `
+| where { 
+    if($_) { $_.StartDate -gt $lastHour -or $_.EndDate -gt $lastHour }
+}

--- a/src/McAuthorization.Bench/Data/Models.json
+++ b/src/McAuthorization.Bench/Data/Models.json
@@ -108,5 +108,21 @@
     "Prop1": "Foo",
     "Prop2": "FooBar",
     "Prop3": 5
+  },
+  {
+    "Prop1": "Foo",
+    "Prop2": "FooBar",
+    "Prop3": 5
+  },
+  {
+    "ConnectorName": "Foo",
+    "ConnectorTypeName": "FooBar",
+    "Prop3": 5
+  },
+  {
+    "Name": "FooBarBaz",
+    "ConnectorName": "Foo",
+    "ConnectorTypeName": "FooBar",
+    "Prop3": 5
   }
 ]

--- a/src/McAuthorization.Bench/Data/Rules.json
+++ b/src/McAuthorization.Bench/Data/Rules.json
@@ -40,5 +40,15 @@
     "ModelProperty": "Prop2",
     "ModelValue": "*Bar*",
     "ModelValues": []
+  },
+  {
+    "Id": "4A6AE1E9-1A6E-40BC-87CA-E0320E179ED8",
+    "Context": "That",
+    "Role": "Alice",
+    "ClaimProperty": "",
+    "ClaimValue": "",
+    "ModelProperty": "*Name",
+    "ModelValue": "*Bar*",
+    "ModelValues": []
   }
 ]

--- a/src/McAuthorization.Bench/Program.cs
+++ b/src/McAuthorization.Bench/Program.cs
@@ -42,12 +42,40 @@ namespace McAuthorization.Bench
             }
             stopwatch.Stop();
 
+            // Load Test Models as Dictionary<string, object>
+            var models2 = new List<Dictionary<string, object>>();
+            using (var modelFile = System.IO.File.OpenText("./Data/Models.json"))
+            {
+                var text = modelFile.ReadToEnd();
+                models2 = Newtonsoft.Json.JsonConvert.DeserializeObject<List<Dictionary<string, object>>>(text);
+            }
+
+            var stopwatch2 = new Stopwatch();
+            var roles2 = new string[] { "Guy" };
+            int count2 = 0;
+            stopwatch2.Start();
+            for (var i = 0; i < cycles; i++)
+            {
+                var matches2 = models2.Any(x => Filter.IsAuthorized(x, "This", roles2));
+                if (matches2) count2++;
+            }
+            stopwatch2.Stop();
+
+            Console.WriteLine("Matching POCO data objects.");
             Console.WriteLine($"Rules loaded: {rules.Count}");
             Console.WriteLine($"Models loaded: {models.Count}");
             Console.WriteLine($"Cyles: {(float)cycles / 1000.0} k");
             Console.WriteLine($"Elapsed miliseconds: {stopwatch.ElapsedMilliseconds}");
             Console.WriteLine($"Elapsed seconds: {stopwatch.ElapsedMilliseconds / 1000.0}");
             Console.WriteLine($"Match count: {count}");
+            Console.WriteLine();
+            Console.WriteLine("Matching Dictionary data objects.");
+            Console.WriteLine($"Rules loaded: {rules.Count}");
+            Console.WriteLine($"Models loaded: {models2.Count}");
+            Console.WriteLine($"Cyles: {(float)cycles / 1000.0} k");
+            Console.WriteLine($"Elapsed miliseconds: {stopwatch2.ElapsedMilliseconds}");
+            Console.WriteLine($"Elapsed seconds: {stopwatch2.ElapsedMilliseconds / 1000.0}");
+            Console.WriteLine($"Match count: {count2}");
         }
     }
 
@@ -56,5 +84,8 @@ namespace McAuthorization.Bench
         public string Prop1 { get; set; }
         public string Prop2 { get; set; }
         public dynamic Prop3 { get; set; }
+        public string Name { get; set; }
+        public string ConnetorName { get; set; }
+        public string ConnetorTypeName { get; set; }
     }
 }

--- a/src/McAuthorization/Filter.cs
+++ b/src/McAuthorization/Filter.cs
@@ -78,5 +78,75 @@ namespace McAuthorization
         {
             return Collection.Where(x => IsAuthorized(x, Context, Roles));
         }
+
+
+        /// <summary>
+        /// For a given Context, an list of Roles, retrieve any matching rules and evaluate them
+        /// against the Model. For AADC controllers it would be obvious
+        /// to check if there is a rule that specifies a role that should allow access to
+        /// connectors with a given name. The rule would for admins accessing my lab connector
+        /// would look like this:
+        ///   Role: "Admin"
+        ///   ModelProperty: "Name"
+        ///   ModelValue: "garage.mcardletech.com"  // actual example used in my lab not shilling my website,
+        ///                                         // it's truly not worth your time.
+        /// </summary>
+        /// <param name="Model"></param>
+        /// <param name="Context"></param>
+        /// <param name="Roles"></param>
+        /// <returns></returns>
+        public static bool IsAuthorized(Dictionary<string, object> Model, string Context, IEnumerable<string> Roles)
+        {
+            var rules = RegisteredRoleControllerRules.GetRoleControllerModelsByContext(Context);
+
+            return (bool)rules.Where(
+                    rule => {
+                        bool result = (bool)Roles?.Any(
+                            role => {
+                                var match = role.Like(rule.Role) || rule.Role.Like(role);
+                                if (!match) { Trace.WriteLine($"Rule role: {rule.Role} doesn't match specified role: {role}"); }
+                                return match;
+                            }); // short circuits when a matching rule is found.
+                                // Returns false if no roles match those defined
+                                // in rules for the specified context.
+                        if (!result)
+                        {
+                            Trace.WriteLine($"Searching for rules for the given context: {Context} and roles: {String.Join(", ", Roles)} yields no results");
+                            // TODO LOGME (Sean) $"Searching for rules for the given context: {Context} and roles: {String.Join(', ', Roles)} yields no results"
+                        }
+                        return result;
+                    })?.Any(rule => {
+                        object testValue = default(object);
+                        var gotValue = Model.TryGetValue(rule.ModelProperty, out testValue);
+
+                        // bail out if there's no value with that key
+                        if (!gotValue) return false;
+
+                        if (rule.ModelValues != null && rule.ModelValues.Count() > 0)
+                        {
+                            return rule.ModelValues.Any(pattern => (bool) testValue?.ToString().Like(pattern));   // Uses Like extension method that supports wildcards
+                                                                                               // so you could say role: GarageAdmins could see all
+                                                                                               // connectors that match: garage.* .
+                        }
+                        else
+                        {
+                            var pattern = rule.ModelValue;
+                            return (bool) testValue?.ToString().Like(pattern);
+                        }
+                    });
+        }
+
+        /// <summary>
+        /// IEnumerable version of IsAuthorized. Allows filtering a collection
+        /// via extension method to make chaining with Linq methods more natural.
+        /// </summary>
+        /// <param name="Collection"></param>
+        /// <param name="Context"></param>
+        /// <param name="Roles"></param>
+        /// <returns></returns>
+        public static IEnumerable<Dictionary<string, object>> IsAuthorized(this IEnumerable<Dictionary<string, object>> Collection, string Context, IEnumerable<string> Roles)
+        {
+            return Collection.Where(x => IsAuthorized(x, Context, Roles));
+        }
     }
 }

--- a/src/McAuthorization/JaroWinkler.cs
+++ b/src/McAuthorization/JaroWinkler.cs
@@ -1,0 +1,230 @@
+﻿/*
+ * The MIT License
+ *
+ * Copyright 2016 feature[23]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using F23.StringSimilarity.Interfaces;
+using System;
+using System.Linq;
+
+namespace F23.StringSimilarity.Interfaces
+{
+    public interface IStringSimilarity
+    {
+        /// <summary>
+        /// Compute and return a measure of similarity between 2 strings.
+        /// </summary>
+        /// <param name="s1">The first string</param>
+        /// <param name="s2">The second string</param>
+        /// <returns>Similarity (0 means both strings are completely different)</returns>
+        double Similarity(string s1, string s2);
+    }
+
+    public interface INormalizedStringSimilarity : IStringSimilarity
+    {
+    }
+
+    public interface IStringDistance
+    {
+        /// <summary>
+        /// Compute and return a measure of distance.
+        /// Must be >= 0.
+        /// </summary>
+        /// <param name="s1"></param>
+        /// <param name="s2"></param>
+        /// <returns></returns>
+        double Distance(string s1, string s2);
+    }
+
+    public interface INormalizedStringDistance : IStringDistance
+    {
+    }
+}
+
+
+namespace F23.StringSimilarity
+{
+    /// The Jaro–Winkler distance metric is designed and best suited for short
+    /// strings such as person names, and to detect typos; it is (roughly) a
+    /// variation of Damerau-Levenshtein, where the substitution of 2 close
+    /// characters is considered less important then the substitution of 2 characters
+    /// that a far from each other.
+    /// Jaro-Winkler was developed in the area of record linkage (duplicate
+    /// detection) (Winkler, 1990). It returns a value in the interval [0.0, 1.0].
+    /// The distance is computed as 1 - Jaro-Winkler similarity.
+    public class JaroWinkler : INormalizedStringSimilarity, INormalizedStringDistance
+    {
+        private const double DEFAULT_THRESHOLD = 0.7;
+        private const int THREE = 3;
+        private const double JW_COEF = 0.1;
+
+        /// <summary>
+        /// The current value of the threshold used for adding the Winkler bonus. The default value is 0.7.
+        /// </summary>
+        private double Threshold { get; set; }
+
+        /// <summary>
+        /// Creates a new instance with default threshold (0.7)
+        /// </summary>
+        public JaroWinkler()
+        {
+            Threshold = DEFAULT_THRESHOLD;
+        }
+
+        /// <summary>
+        /// Creates a new instance with given threshold to determine when Winkler bonus should
+        /// be used. Set threshold to a negative value to get the Jaro distance.
+        /// </summary>
+        /// <param name="threshold"></param>
+        public JaroWinkler(double threshold)
+        {
+            Threshold = threshold;
+        }
+
+        /// <summary>
+        /// Compute Jaro-Winkler similarity.
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>The Jaro-Winkler similarity in the range [0, 1]</returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Similarity(string s1, string s2)
+        {
+            if (s1 == null)
+            {
+                throw new ArgumentNullException("s1");
+            }
+
+            if (s2 == null)
+            {
+                throw new ArgumentNullException("s2");
+            }
+
+            if (s1.Equals(s2))
+            {
+                return 1f;
+            }
+
+            int[] mtp = Matches(s1, s2);
+            float m = mtp[0];
+            if (m == 0)
+            {
+                return 0f;
+            }
+            double j = ((m / s1.Length + m / s2.Length + (m - mtp[1]) / m))
+                    / THREE;
+            double jw = j;
+
+            if (j > Threshold)
+            {
+                jw = j + Math.Min(JW_COEF, 1.0 / mtp[THREE]) * mtp[2] * (1 - j);
+            }
+            return jw;
+        }
+
+        /// <summary>
+        /// Return 1 - similarity.
+        /// </summary>
+        /// <param name="s1">The first string to compare.</param>
+        /// <param name="s2">The second string to compare.</param>
+        /// <returns>1 - similarity</returns>
+        /// <exception cref="ArgumentNullException">If s1 or s2 is null.</exception>
+        public double Distance(string s1, string s2) { return 1.0 - Similarity(s1, s2); }
+
+        private static int[] Matches(string s1, string s2)
+        {
+            string max, min;
+            if (s1.Length > s2.Length)
+            {
+                max = s1;
+                min = s2;
+            }
+            else
+            {
+                max = s2;
+                min = s1;
+            }
+            int range = Math.Max(max.Length / 2 - 1, 0);
+
+            //int[] matchIndexes = new int[min.Length];
+            //Arrays.fill(matchIndexes, -1);
+            int[] match_indexes = Enumerable.Repeat(-1, min.Length).ToArray();
+
+            bool[] match_flags = new bool[max.Length];
+            int matches = 0;
+            for (int mi = 0; mi < min.Length; mi++)
+            {
+                char c1 = min[mi];
+                for (int xi = Math.Max(mi - range, 0),
+                        xn = Math.Min(mi + range + 1, max.Length); xi < xn; xi++)
+                {
+                    if (!match_flags[xi] && c1 == max[xi])
+                    {
+                        match_indexes[mi] = xi;
+                        match_flags[xi] = true;
+                        matches++;
+                        break;
+                    }
+                }
+            }
+            char[] ms1 = new char[matches];
+            char[] ms2 = new char[matches];
+            for (int i = 0, si = 0; i < min.Length; i++)
+            {
+                if (match_indexes[i] != -1)
+                {
+                    ms1[si] = min[i];
+                    si++;
+                }
+            }
+            for (int i = 0, si = 0; i < max.Length; i++)
+            {
+                if (match_flags[i])
+                {
+                    ms2[si] = max[i];
+                    si++;
+                }
+            }
+            int transpositions = 0;
+            for (int mi = 0; mi < ms1.Length; mi++)
+            {
+                if (ms1[mi] != ms2[mi])
+                {
+                    transpositions++;
+                }
+            }
+            int prefix = 0;
+            for (int mi = 0; mi < min.Length; mi++)
+            {
+                if (s1[mi] == s2[mi])
+                {
+                    prefix++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+            return new[] { matches, transpositions / 2, prefix, max.Length };
+        }
+    }
+}

--- a/src/aadcapi.UnitTests/PowerShellRunnerTests.cs
+++ b/src/aadcapi.UnitTests/PowerShellRunnerTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using SMM.Automation;
+using SMM.Helper;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,10 +11,55 @@ namespace aadcapi.UnitTests
 {
     class PowerShellRunnerTests
     {
+        string ParameterValidationScript = String.Empty;
+        string[] validInputs = new string[] { "Hello World!" };
+
         [SetUp]
         public void Setup()
         {
+            ParameterValidationScript = Properties.Resources.PoshValidateParameterScript;
+        }
 
+        [Test]
+        public void TestParameterValidationFromProxyVariable()
+        {
+            var runner = new SimpleScriptRunner("[bool]($validationList -notlike $null)");
+            runner.SetProxyVariable("validationList", validInputs);
+            runner.Run();
+            bool result = false;
+            var extracted = runner.Results.CapturePSResult<bool>().FirstOrDefault();
+            if (extracted is bool value) { result = value; }
+
+            // Will return true if the proxy variable was passed
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void TestParameterValidationFromProxyVariableShouldNotHaveErrors()
+        {
+            var runner = new SimpleScriptRunner(ParameterValidationScript);
+            runner.Parameters.Add("FromOutside", "Hello World!");
+            runner.SetProxyVariable("validationList", validInputs);
+            runner.Run();
+
+            // Hello World! is in the validation list and should not generate an error
+            Assert.IsFalse(runner.HadErrors);
+        }
+
+        [Test]
+        public void TestParameterValidationFromProxyVariableShouldHaveErrors()
+        {
+            var runner = new SimpleScriptRunner(ParameterValidationScript);
+            runner.Parameters.Add("FromOutside", "Hello Universe!");
+            runner.SetProxyVariable("validationList", validInputs);
+            runner.Run();
+            
+            // Should error
+            Assert.IsTrue(runner.HadErrors, "Should throw an error, \"Hello Universe!\" is not in the validation list");
+
+            // Should be a parameter binding error
+            var ex = runner.LastError;
+            Assert.IsTrue(ex is System.Management.Automation.ParameterBindingException, "Parameter validation exception was not thrown but another error was.");
         }
 
         [Test]
@@ -25,9 +71,8 @@ namespace aadcapi.UnitTests
             // runner should show that an error occurred.
             Assert.IsTrue(runner.HadErrors, "PowerShell session did not have errors.");
 
-            var ex = runner.LastError;
-
             // Exception is extracted from ErrorRecord
+            var ex = runner.LastError;
             Assert.IsNotNull(ex, "Exception message not retreived from ErrorRecord.");
 
             // Exception message from inside PowerShell is curried out

--- a/src/aadcapi.UnitTests/PowerShellRunnerTests.cs
+++ b/src/aadcapi.UnitTests/PowerShellRunnerTests.cs
@@ -1,0 +1,47 @@
+﻿using NUnit.Framework;
+using SMM.Automation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace aadcapi.UnitTests
+{
+    class PowerShellRunnerTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+
+        }
+
+        [Test]
+        public void TestCapturingException()
+        {
+            var runner = new SimpleScriptRunner("throw New-Object System.Exception 'Thrown from PowerShell'");
+            runner.Run();
+
+            // runner should show that an error occurred.
+            Assert.IsTrue(runner.HadErrors, "PowerShell session did not have errors.");
+
+            var ex = runner.LastError;
+
+            // Exception is extracted from ErrorRecord
+            Assert.IsNotNull(ex, "Exception message not retreived from ErrorRecord.");
+
+            // Exception message from inside PowerShell is curried out
+            Assert.IsTrue((ex.Message.Equals("Thrown from PowerShell")), "Couldn't get message from PowerShell exception.");
+        }
+
+        [Test]
+        public void TestCodeInjectionByParameter()
+        {
+            var runner = new SimpleScriptRunner("param([string]$stringIn) Write-Host Testing $stringIn");
+            runner.Parameters.Add("stringIn", "; Write-Output 'Should be on the same line.'");
+            runner.Run();
+
+            Assert.IsTrue(runner.Results.Count == 1);
+        }
+    }
+}

--- a/src/aadcapi.UnitTests/Properties/Resources.Designer.cs
+++ b/src/aadcapi.UnitTests/Properties/Resources.Designer.cs
@@ -61,7 +61,34 @@ namespace aadcapi.UnitTests.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {&quot;Id&quot;:&quot;424e5cfd-5139-417c-9300-79aa0fabc3c1&quot;,&quot;Role&quot;:&quot;Admin:Garage&quot;,&quot;Context&quot;:&quot;Connector&quot;,&quot;ClaimProperty&quot;:&quot;&quot;,&quot;ClaimValue&quot;:&quot;&quot;,&quot;ModelProperty&quot;:&quot;Name&quot;,&quot;ModelValue&quot;:&quot;garage.mcardletech.com&quot;,&quot;ModelValues&quot;:null}.
+        ///   Looks up a localized string similar to function TestingParameterValidation {
+        ///    param ( 
+        ///        [ValidateScript({$_ -in $validationList})]
+        ///        $TestInput
+        ///    )
+        ///
+        ///    $TestInput
+        ///}.
+        /// </summary>
+        internal static string PoshValidateParameterScript {
+            get {
+                return ResourceManager.GetString("PoshValidateParameterScript", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [
+        ///	{
+        ///		&quot;Id&quot;: &quot;424e5cfd-5139-417c-9300-79aa0fabc3c1&quot;,
+        ///		&quot;Role&quot;: &quot;Admin:Garage&quot;,
+        ///		&quot;Context&quot;: &quot;Connector&quot;,
+        ///		&quot;ClaimProperty&quot;: &quot;&quot;,
+        ///		&quot;ClaimValue&quot;: &quot;&quot;,
+        ///		&quot;ModelProperty&quot;: &quot;Foo&quot;,
+        ///		&quot;ModelValue&quot;: &quot;Bar&quot;,
+        ///		&quot;ModelValues&quot;: null
+        ///	}
+        ///].
         /// </summary>
         internal static string TestRules {
             get {

--- a/src/aadcapi.UnitTests/Properties/Resources.resx
+++ b/src/aadcapi.UnitTests/Properties/Resources.resx
@@ -118,6 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="PoshValidateParameterScript" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\PoshValidateParameterScript.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
   <data name="TestRules" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\TestRules.json;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>

--- a/src/aadcapi.UnitTests/Resources/PoshValidateParameterScript.txt
+++ b/src/aadcapi.UnitTests/Resources/PoshValidateParameterScript.txt
@@ -1,0 +1,12 @@
+﻿param ($FromOutside)
+
+function TestingParameterValidation {
+    param ( 
+        [ValidateScript({$_ -in $validationList})]
+        $TestInput
+    )
+
+    $TestInput
+}
+
+TestingParameterValidation -TestInput $FromOutside

--- a/src/aadcapi/Controllers/Server/AADPasswordResetConfigurationController.cs
+++ b/src/aadcapi/Controllers/Server/AADPasswordResetConfigurationController.cs
@@ -1,0 +1,36 @@
+﻿using SMM.Automation;
+using SMM.Helper;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+
+namespace aadcapi.Controllers.Server
+{
+    [Authorize]
+    public class AADPasswordResetConfigurationController : ApiController
+    {
+        /// <summary>
+        /// Maps to Get-ADSyncAADPasswordResetConfiguration cmdlet. Shows the status of 
+        /// the tenant wide feature. Only applies to the AAD connector so that is automatically
+        /// resolved. If more than one AAD connector is found an exception is thrown as this is
+        /// not a supported configuration.
+        /// </summary>
+        public dynamic Get()
+        {
+            var runner = new SimpleScriptRunner(Properties.Resources.Get_ADSyncAADPasswordResetConfiguration);
+            runner.Run();
+
+            if (runner.HadErrors)
+            {
+                var err = runner.LastError ?? new Exception("Encountered an error in PowerShell but could not capture the exception.");
+                return InternalServerError(err);
+            }
+
+            var result = Ok(runner.Results.ToDict().FirstOrDefault());
+            return result;
+        }
+    }
+}

--- a/src/aadcapi/Controllers/Server/AutoUpgradeController.cs
+++ b/src/aadcapi/Controllers/Server/AutoUpgradeController.cs
@@ -12,9 +12,14 @@ namespace aadcapi.Controllers.Server
     [Authorize]
     public class AutoUpgradeController : ApiController
     {
+        /// <summary>
+        /// Maps to Get-ADSyncAutoUpgrade. This feature is only available when using LocalDB
+        /// in a supported configuration. If status is not "Enabled" detail is given as to why.
+        /// </summary>
+        /// <returns></returns>
         public dynamic Get()
         {
-            var runner = new SimpleScriptRunner("Get-ADSyncAutoUpgrade");
+            var runner = new SimpleScriptRunner(Properties.Resources.Get_ADSyncAutoUpgrade);
             runner.Run();
 
             if (runner.HadErrors)

--- a/src/aadcapi/Controllers/Server/AutoUpgradeController.cs
+++ b/src/aadcapi/Controllers/Server/AutoUpgradeController.cs
@@ -1,0 +1,30 @@
+﻿using SMM.Automation;
+using SMM.Helper;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+
+namespace aadcapi.Controllers.Server
+{
+    [Authorize]
+    public class AutoUpgradeController : ApiController
+    {
+        public dynamic Get()
+        {
+            var runner = new SimpleScriptRunner("Get-ADSyncAutoUpgrade");
+            runner.Run();
+
+            if (runner.HadErrors)
+            {
+                var err = runner.LastError ?? new Exception("Encountered an error in PowerShell but could not capture the exception.");
+                return InternalServerError(err);
+            }
+
+            var result = Ok(runner.Results.ToDict().FirstOrDefault());
+            return result;
+        }
+    }
+}

--- a/src/aadcapi/Controllers/Server/ConnectorStatisticsController.cs
+++ b/src/aadcapi/Controllers/Server/ConnectorStatisticsController.cs
@@ -1,0 +1,50 @@
+﻿using aadcapi.Utils.Authorization;
+using SMM.Automation;
+using SMM.Helper;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+
+namespace aadcapi.Controllers.Server
+{
+    [Authorize]
+    public class ConnectorStatisticsController : ApiController
+    {
+        /// <summary>
+        /// Maps to Get-ADSyncConnectorStatistics cmdlet. This returns the current
+        /// number of connectors and pending import and export operations for a given
+        /// connector. Use case: if synchronization is taking much longer than usual, perhaps
+        /// there are many more connectors (objects) to synchronize. Monitoring these
+        /// results for change over time can give an indication of that.
+        /// </summary>
+        /// <param name="Name">Name of a valid AADC connector.</param>
+        public dynamic Get(string Name)
+        {
+            if (String.IsNullOrEmpty(Name))
+            {
+                return BadRequest("Must specify a valid connector name.");
+            }
+
+            if (!this.IsAuthorized(new { Context = "Connector", Name = Name, Id = Name })) {
+                throw new HttpResponseException(HttpStatusCode.Unauthorized);
+            }
+
+            // Run PowerShell command to get AADC connector configurations
+            var runner = new SimpleScriptRunner("param($ConnectorName) Get-ADSyncConnectorStatistics -ConnectorName $ConnectorName");
+            runner.Parameters.Add("ConnectorName", Name);
+            runner.Run();
+
+            if (runner.HadErrors)
+            {
+                var err = runner.LastError ?? new Exception("Encountered an error in PowerShell but could not capture the exception.");
+                return InternalServerError(err);
+            }
+
+            var result = Ok(runner.Results.ToDict().FirstOrDefault());
+            return result;
+        }
+    }
+}

--- a/src/aadcapi/Controllers/Server/ConnectorStatisticsController.cs
+++ b/src/aadcapi/Controllers/Server/ConnectorStatisticsController.cs
@@ -1,4 +1,5 @@
 ﻿using aadcapi.Utils.Authorization;
+using McAuthorization;
 using SMM.Automation;
 using SMM.Helper;
 using System;
@@ -6,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Security.Claims;
 using System.Web.Http;
 
 namespace aadcapi.Controllers.Server
@@ -19,6 +21,10 @@ namespace aadcapi.Controllers.Server
         /// connector. Use case: if synchronization is taking much longer than usual, perhaps
         /// there are many more connectors (objects) to synchronize. Monitoring these
         /// results for change over time can give an indication of that.
+        /// 
+        /// Note: you must be authenticated with valid role claims before calling into
+        /// this or you will receive a 403 Forbidden. Returning a 401 can result in an
+        /// infinate redirect loop with Azure AD.
         /// </summary>
         /// <param name="Name">Name of a valid AADC connector.</param>
         public dynamic Get(string Name)
@@ -28,8 +34,13 @@ namespace aadcapi.Controllers.Server
                 return BadRequest("Must specify a valid connector name.");
             }
 
-            if (!this.IsAuthorized(new { Context = "Connector", Name = Name, Id = Name })) {
-                throw new HttpResponseException(HttpStatusCode.Unauthorized);
+            // Construct an anonymous object as the Model for IsAuthorized so we can
+            // pass in Connector as the context. This will allow the authorization engine
+            // to re-use the rules for /api/Connector. If you have rights to view a given
+            // connector, there is no reason you shouldn't see it's statistics.
+            var roles = ((ClaimsPrincipal)RequestContext.Principal).RoleClaims();
+            if (!Filter.IsAuthorized<dynamic>(new { Name = Name, ConnectorName = Name, Identifier = Name }, "Connector", roles)) {
+                throw new HttpResponseException(HttpStatusCode.Forbidden);
             }
 
             // Run PowerShell command to get AADC connector configurations

--- a/src/aadcapi/Controllers/Server/DomainReachabilityStatusController.cs
+++ b/src/aadcapi/Controllers/Server/DomainReachabilityStatusController.cs
@@ -21,7 +21,6 @@ namespace aadcapi.Controllers.Server
         /// connectivity related no-start-ma sync status messages.
         /// </summary>
         /// <param name="Name"></param>
-        /// <returns></returns>
         public dynamic Get(string Name)
         {
             // Run PowerShell command to get AADC connector configurations

--- a/src/aadcapi/Controllers/Server/DomainReachabilityStatusController.cs
+++ b/src/aadcapi/Controllers/Server/DomainReachabilityStatusController.cs
@@ -1,0 +1,53 @@
+﻿using aadcapi.Models;
+using aadcapi.Utils.Authorization;
+using McAuthorization;
+using SMM.Automation;
+using SMM.Helper;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Web.Http;
+
+namespace aadcapi.Controllers.Server
+{
+    [Authorize]
+    public class DomainReachabilityStatusController : ApiController
+    {
+        /// <summary>
+        /// Maps to Get-ADSyncDomainReachabilityStatus cmdlet. This can be used for troubleshooting
+        /// connectivity related no-start-ma sync status messages.
+        /// </summary>
+        /// <param name="Name"></param>
+        /// <returns></returns>
+        public dynamic Get(string Name)
+        {
+            // Run PowerShell command to get AADC connector configurations
+            var runner = new SimpleScriptRunner(aadcapi.Properties.Resources.Get_ADSyncDomainReachabilityStatus);
+            runner.Parameters.Add("ConnectorName", Name);
+            runner.Run();
+
+            // Map PowerShell objects to models, C# classes with matching property names.
+            // All results should be DomainReachabilityStatus but CapturePSResult can return as
+            // type: dynamic if the PowerShell object doesn't successfully map to the
+            // desired model type. For those that are the correct model, we pass them
+            // to the IsAuthorized method which loads and runs any rules for this connector
+            // who match the requestors roles.
+            var resultValues = runner.Results.CapturePSResult<DomainReachabilityStatus>()
+                .Where(x => x is DomainReachabilityStatus)     // Filter out results that couldn't be captured as DomainReachabilityStatus.
+                .Select(x => x as DomainReachabilityStatus);   // Take as DomainReachabilityStatus so typed call to WhereAuthorized avoids GetType() call.
+
+            resultValues = this.WhereAuthorized<DomainReachabilityStatus>(resultValues);
+
+            if (resultValues != null)
+            {
+                var result = Ok(resultValues);
+                return result;
+            }
+
+            return Ok();
+        }
+    }
+}

--- a/src/aadcapi/Controllers/Server/ExportDeletionThresholdController.cs
+++ b/src/aadcapi/Controllers/Server/ExportDeletionThresholdController.cs
@@ -1,0 +1,34 @@
+﻿using SMM.Automation;
+using SMM.Helper;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+
+namespace aadcapi.Controllers.Server
+{
+    [Authorize]
+    public class ExportDeletionThresholdController : ApiController
+    {
+        /// <summary>
+        /// Maps to Get-ADSyncExportDeletionThreshold cmdlet. This gives enabled/disabled (1/0)
+        /// status and the numeric value of the current threshold.
+        /// </summary>
+        public dynamic Get()
+        {
+            var runner = new SimpleScriptRunner("Get-ADSyncExportDeletionThreshold");
+            runner.Run();
+
+            if (runner.HadErrors)
+            {
+                var err = runner.LastError ?? new Exception("Encountered an error in PowerShell but could not capture the exception.");
+                return InternalServerError(err);
+            }
+
+            var result = Ok(runner.Results.ToDict().FirstOrDefault());
+            return result;
+        }
+    }
+}

--- a/src/aadcapi/Models/DomainReachabilityStatus.cs
+++ b/src/aadcapi/Models/DomainReachabilityStatus.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace aadcapi.Models
+{
+    public class DomainReachabilityStatus
+    {
+        public dynamic FullName { get; set; }
+        public dynamic IsReachable { get; set; }
+        public dynamic ExceptionMessage { get; set; }
+    }
+}

--- a/src/aadcapi/Properties/Resources.Designer.cs
+++ b/src/aadcapi/Properties/Resources.Designer.cs
@@ -170,6 +170,17 @@ namespace aadcapi.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to param ($ConnectorName)
+        ///
+        ///Get-ADSyncDomainReachabilityStatus -ConnectorName $ConnectorName.
+        /// </summary>
+        internal static string Get_ADSyncDomainReachabilityStatus {
+            get {
+                return ResourceManager.GetString("Get-ADSyncDomainReachabilityStatus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to $global_config = Get-ADSyncGlobalSettings
         ///$parameters = @{}
         ///$global_config.Parameters | foreach {

--- a/src/aadcapi/Properties/Resources.Designer.cs
+++ b/src/aadcapi/Properties/Resources.Designer.cs
@@ -61,6 +61,21 @@ namespace aadcapi.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to $connector = @(Get-ADSyncConnector | ? Type -like &quot;Extensible2&quot; | ? Subtype -like &quot;Windows Azure Active Directory*&quot;)
+        ///
+        ///if ($connector.Count -gt 1) {
+        ///    throw &quot;Unsupported AADC configuration. More than one AAD connector is not supported.&quot;
+        ///}
+        ///
+        ///Get-ADSyncAADPasswordResetConfiguration -Connector ($connector.Name).
+        /// </summary>
+        internal static string Get_ADSyncAADPasswordResetConfiguration {
+            get {
+                return ResourceManager.GetString("Get-ADSyncAADPasswordResetConfiguration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to param($SourceConnector)
         ///
         ///Get-ADSyncAADPasswordSyncConfiguration -SourceConnector $SourceConnector.

--- a/src/aadcapi/Properties/Resources.Designer.cs
+++ b/src/aadcapi/Properties/Resources.Designer.cs
@@ -87,6 +87,22 @@ namespace aadcapi.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to $state  = Get-ADSyncAutoUpgrade -Detail
+        ///$props  = $state | GM | ? MemberType -like &quot;Property&quot;
+        ///$result = New-Object PSObject
+        ///$props | foreach {
+        ///    $val = $state.($_.Name)
+        ///    $result | Add-Member -MemberType NoteProperty -Name ($_.Name) -Value ([string]$val)
+        ///}
+        ///$result.
+        /// </summary>
+        internal static string Get_ADSyncAutoUpgrade {
+            get {
+                return ResourceManager.GetString("Get-ADSyncAutoUpgrade", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to param ($Name)
         ///
         ///Import-Module ADSync;

--- a/src/aadcapi/Properties/Resources.resx
+++ b/src/aadcapi/Properties/Resources.resx
@@ -225,6 +225,11 @@ $attributes = @(
 
 Get-ADSyncCSObject -ConnectorName $ConnectorName -DistinguishedName $DistinguishedName | select $attributes</value>
   </data>
+  <data name="Get-ADSyncDomainReachabilityStatus" xml:space="preserve">
+    <value>param ($ConnectorName)
+
+Get-ADSyncDomainReachabilityStatus -ConnectorName $ConnectorName</value>
+  </data>
   <data name="Get-AdSyncGlobalSettingsStrict" xml:space="preserve">
     <value>$global_config = Get-ADSyncGlobalSettings
 $parameters = @{}

--- a/src/aadcapi/Properties/Resources.resx
+++ b/src/aadcapi/Properties/Resources.resx
@@ -117,6 +117,15 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Get-ADSyncAADPasswordResetConfiguration" xml:space="preserve">
+    <value>$connector = @(Get-ADSyncConnector | ? Type -like "Extensible2" | ? Subtype -like "Windows Azure Active Directory*")
+
+if ($connector.Count -gt 1) {
+    throw "Unsupported AADC configuration. More than one AAD connector is not supported."
+}
+
+Get-ADSyncAADPasswordResetConfiguration -Connector ($connector.Name)</value>
+  </data>
   <data name="Get-ADSyncAADPasswordSyncConfiguration" xml:space="preserve">
     <value>param($SourceConnector)
 

--- a/src/aadcapi/Properties/Resources.resx
+++ b/src/aadcapi/Properties/Resources.resx
@@ -131,6 +131,16 @@ Get-ADSyncAADPasswordResetConfiguration -Connector ($connector.Name)</value>
 
 Get-ADSyncAADPasswordSyncConfiguration -SourceConnector $SourceConnector</value>
   </data>
+  <data name="Get-ADSyncAutoUpgrade" xml:space="preserve">
+    <value>$state  = Get-ADSyncAutoUpgrade -Detail
+$props  = $state | GM | ? MemberType -like "Property"
+$result = New-Object PSObject
+$props | foreach {
+    $val = $state.($_.Name)
+    $result | Add-Member -MemberType NoteProperty -Name ($_.Name) -Value ([string]$val)
+}
+$result</value>
+  </data>
   <data name="Get-ADSyncConnectorsBasic" xml:space="preserve">
     <value>param ($Name)
 

--- a/src/aadcapi/SMM/Extensions.cs
+++ b/src/aadcapi/SMM/Extensions.cs
@@ -99,6 +99,12 @@ namespace SMM.Helper
             bool captureSuccess = true;
 
             try {
+                if (typeof(T) == typeof(bool))
+                {
+                    result = Convert.ToBoolean(input.BaseObject);
+                    return result;
+                }
+
                 result = Activator.CreateInstance(asType);
                 var hintType = asType.GetTypeInfo();
                 var props = hintType.DeclaredProperties;

--- a/src/aadcapi/SMM/SimpleScriptRunner.cs
+++ b/src/aadcapi/SMM/SimpleScriptRunner.cs
@@ -138,6 +138,14 @@ namespace SMM.Automation
                     }
                 }
 
+                if (this.proxyVariables.Count != 0)
+                {
+                    foreach (var v in proxyVariables)
+                    {
+                        currentPowerShell.Runspace.SessionStateProxy.SetVariable(v.Item1, v.Item2);
+                    }
+                }
+
                 // Add the default outputter to the end of the pipe and then
                 // call the MergeMyResults method to merge the output and
                 // error streams from the pipeline. This will result in the

--- a/src/aadcapi/Utils/Authorization/ControllerAuthorizationExtensions.cs
+++ b/src/aadcapi/Utils/Authorization/ControllerAuthorizationExtensions.cs
@@ -75,5 +75,43 @@ namespace aadcapi.Utils.Authorization
 
             return Filter.IsAuthorized<T>(Model, context, roles);
         }
+
+        /// <summary>
+        /// Given a controller, filter a collection of objects that the principal can access in that context.
+        /// Simply a helper function so filtering a collection from within a controller can be simplified.
+        /// </summary>
+        /// <param name="Controller"></param>
+        /// <param name="Collection"></param>
+        /// <returns></returns>
+        public static IEnumerable<Dictionary<string, object>> WhereAuthorized(this ApiController Controller, IEnumerable<Dictionary<string, object>> Collection)
+        {
+            var context = Controller.ControllerName();
+            var roles = ((ClaimsPrincipal)Controller?.RequestContext?.Principal)?.RoleClaims();
+            if (roles != null)
+            {
+                // TODO LOGME (Sean) log null role set
+            }
+
+            return Collection.Where(x => Filter.IsAuthorized(x, context, roles));
+        }
+
+        /// <summary>
+        /// IsAuthorized extension method for evaluating rules against a single object
+        /// from within a controller method.
+        /// </summary>
+        /// <param name="Controller"></param>
+        /// <param name="Model"></param>
+        /// <returns></returns>
+        public static bool IsAuthorized(this ApiController Controller, Dictionary<string, object> Model)
+        {
+            var context = Controller.ControllerName();
+            var roles = ((ClaimsPrincipal)Controller?.RequestContext?.Principal)?.RoleClaims();
+            if (roles != null)
+            {
+                // TODO LOGME (Sean) log null role set
+            }
+
+            return Filter.IsAuthorized(Model, context, roles);
+        }
     }
 }

--- a/src/aadcapi/aadcapi.csproj
+++ b/src/aadcapi/aadcapi.csproj
@@ -538,6 +538,7 @@
     <Compile Include="Controllers\Server\AADPasswordResetConfigurationController.cs" />
     <Compile Include="Controllers\Server\AADPasswordSyncController.cs" />
     <Compile Include="Controllers\Server\AutoUpgradeController.cs" />
+    <Compile Include="Controllers\Server\ConnectorStatisticsController.cs" />
     <Compile Include="Controllers\Server\CSObjectController.cs" />
     <Compile Include="Controllers\Server\DomainReachabilityStatusController.cs" />
     <Compile Include="Controllers\Server\ExportDeletionThresholdController.cs" />

--- a/src/aadcapi/aadcapi.csproj
+++ b/src/aadcapi/aadcapi.csproj
@@ -540,6 +540,7 @@
     <Compile Include="Controllers\Server\AutoUpgradeController.cs" />
     <Compile Include="Controllers\Server\CSObjectController.cs" />
     <Compile Include="Controllers\Server\DomainReachabilityStatusController.cs" />
+    <Compile Include="Controllers\Server\ExportDeletionThresholdController.cs" />
     <Compile Include="Controllers\Server\GlobalSettingsController.cs" />
     <Compile Include="Controllers\Server\MVObjectController.cs" />
     <Compile Include="Controllers\Server\PartitionPasswordSyncStateController.cs" />

--- a/src/aadcapi/aadcapi.csproj
+++ b/src/aadcapi/aadcapi.csproj
@@ -537,6 +537,7 @@
     <Compile Include="Controllers\Server\AADCompanyFeature.cs" />
     <Compile Include="Controllers\Server\AADPasswordResetConfigurationController.cs" />
     <Compile Include="Controllers\Server\AADPasswordSyncController.cs" />
+    <Compile Include="Controllers\Server\AutoUpgradeController.cs" />
     <Compile Include="Controllers\Server\CSObjectController.cs" />
     <Compile Include="Controllers\Server\GlobalSettingsController.cs" />
     <Compile Include="Controllers\Server\MVObjectController.cs" />

--- a/src/aadcapi/aadcapi.csproj
+++ b/src/aadcapi/aadcapi.csproj
@@ -535,6 +535,7 @@
     <Compile Include="Controllers\HomeController.cs" />
     <Compile Include="Controllers\MeController.cs" />
     <Compile Include="Controllers\Server\AADCompanyFeature.cs" />
+    <Compile Include="Controllers\Server\AADPasswordResetConfigurationController.cs" />
     <Compile Include="Controllers\Server\AADPasswordSyncController.cs" />
     <Compile Include="Controllers\Server\CSObjectController.cs" />
     <Compile Include="Controllers\Server\GlobalSettingsController.cs" />

--- a/src/aadcapi/aadcapi.csproj
+++ b/src/aadcapi/aadcapi.csproj
@@ -539,6 +539,7 @@
     <Compile Include="Controllers\Server\AADPasswordSyncController.cs" />
     <Compile Include="Controllers\Server\AutoUpgradeController.cs" />
     <Compile Include="Controllers\Server\CSObjectController.cs" />
+    <Compile Include="Controllers\Server\DomainReachabilityStatusController.cs" />
     <Compile Include="Controllers\Server\GlobalSettingsController.cs" />
     <Compile Include="Controllers\Server\MVObjectController.cs" />
     <Compile Include="Controllers\Server\PartitionPasswordSyncStateController.cs" />
@@ -550,6 +551,7 @@
     </Compile>
     <Compile Include="Models\AadcConnector.cs" />
     <Compile Include="Models\AadcCSObject.cs" />
+    <Compile Include="Models\DomainReachabilityStatus.cs" />
     <Compile Include="Models\PasswordSyncState.cs" />
     <Compile Include="Utils\Authorization\ControllerAuthorizationExtensions.cs" />
     <Compile Include="Models\SyncResult.cs" />


### PR DESCRIPTION
Added more command for debugging and monitoring connectors as well as settings which apply to the AAD connector/tenant. The authorization rules engine was also updated to use a string likeness algorithm for selecting which property to compare against when the ModelProperty specified contains wildcard characters. This results in the rule evaluating against the ConnectorName property instead of ConnectorTypeName when "*Name" is the specified model property. Should result in more expected behavior because the property name with the closest match will be selected.